### PR TITLE
DEVOPS-110555: Rollback to 0.3.1, update docker image for alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 COPY . /go/src/metacontroller.app/
 WORKDIR /go/src/metacontroller.app/
+ENV CGO_ENABLED=0
 RUN dep ensure && go install
 
-FROM debian:stretch-slim
-RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM r1k8sacrdev.azurecr.io/r1/base/security-alpine3:v3
+RUN apk update && apk add --no-cache ca-certificates && apk add --update bash
 COPY --from=build /go/bin/metacontroller.app /usr/bin/metacontroller
+RUN chown -R 2000:2000 /usr/bin/metacontroller
+USER 2000
 CMD ["/usr/bin/metacontroller"]

--- a/publish_metacontroller.sh
+++ b/publish_metacontroller.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+version=0.3.1-ALPINE
+
+while getopts n: option
+do
+    case "${option}" in
+        n) ACR=${OPTARG};;
+    esac
+done
+
+if [[ "${ACR}" != "r1k8sacrdev" ]] && [[ "${ACR}" != "r1k8sacrtest" ]]; then
+    echo "Unexpected container registry: ${ACR}.  Expect: r1k8sacrdev or r1k8sacrtest"
+    exit 1
+fi
+
+echo "Logging into ${ACR} container registry."
+az acr login -n ${ACR}
+
+imageName=${ACR}.azurecr.io/r1/c4/metacontroller:v$version
+echo "Building image $imageName from docker file"
+docker build -t $imageName .
+docker push $imageName


### PR DESCRIPTION
DEVOPS-110555: Rollback to 0.3.1, update docker image for alpine base, add publish script